### PR TITLE
Persistent participants feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It can be a useful tool for agile remote teams.
 - Automatically adds active (online) users of current channel as participants
 to poker planning sessions
 - You can also explicitly set the participants with `@user`, `@channel`, `@here` and `@group` mentions
+- or pre-configure participants with `/pp config participants @user1 @user2` for your planning sessions
 - Once all the participants are voted, the votes are automatically revealed
 - Customizable poker values for your team
 

--- a/migrations/001-initial-schema.sql
+++ b/migrations/001-initial-schema.sql
@@ -6,6 +6,10 @@ CREATE TABLE team (
     scope VARCHAR(255) NOT NULL,
     user_id VARCHAR(255) NOT NULL
 );
-
+CREATE TABLE participants (
+    room VARCHAR(255) PRIMARY KEY,
+    id VARCHAR(255) NOT NULL,
+    members TEXT);
 -- Down
 DROP TABLE team;
+DROP TABLE participants;


### PR DESCRIPTION
WHY?

This feature is quite useful for my scrum planning workflow. We usually do 20 planning sessions at the time so pre-configuring participants is handy. Using slack groups are not flexible enough for what I wanted to do so I added this feature.

Adding a new config option: /pp config participants @user1 @user2 ...

Same idea than /pp some topic text @user1 @user2 but instead you preconfigure users so they persist across multiple planning sessions for the room that you are in. This is useful when you don't want to default to @here or use Slack groups and you're too lazy to specify users at every estimate sessions.

WHAT?

/pp config participants @user1 @user2 ... command saves users in DB tied to a specific Slack room. Those pre-set users can be deleted and default back to @here by using /pp config reset