### PR TITLE
 #28 Order points in the relieved screen by their original order

### DIFF
--- a/src/session/session-controller.ts
+++ b/src/session/session-controller.ts
@@ -313,7 +313,7 @@ export class SessionController {
         (userId) => session.votes[userId] || 'not-voted'
       );
       const votesText = Object.keys(voteGroups)
-        .sort()
+        .sort((a, b) => session.points.indexOf(a) - session.points.indexOf(b))
         .map((point) => {
           const votes = voteGroups[point];
           const peopleText =


### PR DESCRIPTION


I use the original points array as the sort function for the sorting of the votes groups. 

This should return the points in their original order. 

I could not see a test folder, so I have not included a test for this, let me know if there is one I have missed