### PR TITLE
Read REDIS_URL env variable

### DIFF
--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -11,7 +11,7 @@ export async function init() {
   }
 
   logger.info({ msg: `Creating redis client...` });
-  client = redis.createClient();
+  client = redis.createClient(process.env.REDIS_URL);
 
   await new Promise((resolve, reject) => {
     client.once('ready', resolve);


### PR DESCRIPTION
Although the environment variable REDIS_URL is maintained in `.env`, it is actually not used in the code and also the node-redis library does not use it. With this change the environment variable is explicitly read and used when initialising Redis.

See https://github.com/dgurkaynak/slack-poker-planner/issues/38