### PR TITLE
Resolve potential reflected XSS vulnerability in OAuth endpoint

### DIFF
--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -13,11 +13,12 @@ export class OAuthRoute {
   static async handle(req: express.Request, res: express.Response) {
     // Slack-side error, display error message
     if (req.query.error) {
+      const sanitizedError = encodeURIComponent(req.query.error as string);
       logger.error({
         msg: `Could not oauth`,
         err: req.query.error,
       });
-      return res.status(500).send(req.query.error);
+      return res.status(500).send(sanitizedError);
     }
 
     // Installed!


### PR DESCRIPTION
When there's a 500 error returned on the OAuth endpoint, the endpoint returns the error message exactly as sent by the requester. This can lead to reflected cross-site scripting, so I've added URL encoding to sanitize the response before it's returned.